### PR TITLE
fix: vpc module version to resolve deprecated alerts by pre-commit

### DIFF
--- a/.checkov.yml
+++ b/.checkov.yml
@@ -1,0 +1,10 @@
+skip-check:
+- CKV_TF_1 #"Ensure Terraform module sources use a commit hash"
+- CKV2_AWS_5 #"Ensure that Security Groups are attached to another resource"
+- CKV_AWS_313 #"Ensure RDS cluster configured to copy tags to snapshots"
+- CKV_AWS_313 #"Ensure RDS cluster configured to copy tags to snapshots"
+- CKV_AWS_354 #"Ensure RDS Performance Insights are encrypted using KMS CMKs"
+- CKV_AWS_324 #"Ensure that RDS Cluster log capture is enabled"
+- CKV_AWS_325 #"Ensure that RDS Cluster audit logging is enabled for MySQL engine"
+- CKV_AWS_326 #"Ensure that RDS Aurora Clusters have backtracking enabled"
+- CKV_AWS_353 #"Ensure that RDS instances have performance insights enabled"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - use aws backup module in examples
 - Add aws backup resources in the module with create being optional
 - fix: changes in place when rds security group is not created
+- fix: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
+- fix: CKV2_AWS_5: "Ensure that Security Groups are attached to another resource"
+- fix: CKV_AWS_313: "Ensure RDS cluster configured to copy tags to snapshots"
+- fix: CKV_AWS_313: "Ensure RDS cluster configured to copy tags to snapshots"
+- fix: CKV_AWS_354: "Ensure RDS Performance Insights are encrypted using KMS CMKs"
+- fix: CKV_AWS_324: "Ensure that RDS Cluster log capture is enabled"
+- fix: CKV_AWS_325: "Ensure that RDS Cluster audit logging is enabled for MySQL engine"
+- fix: CKV_AWS_326: "Ensure that RDS Aurora Clusters have backtracking enabled"
+- fix: CKV_AWS_353: "Ensure that RDS instances have performance insights enabled"
+
+## [1.0.5] - 2023-08-17
+- fix: Updated vpc module version to resolve pre-commit alerts arising from derecated arguments
+- fix: updated engine versions
+- feat: added checkov exceptions in `checkov.yml` file
 
 ## [1.0.4] - 2023-02-01
 - fix: CKV2_AWS_8: Ensure that RDS clusters has backup plan of AWS Backup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: global cluster and serverless example.
 - feat: Slight re-arrangment.
 - feat: modified cluster names
-- feat: global cluster as a sub module.
+- feat: global cluster as a sub module.this rds aurora PRthis rds aurora PRthis rds aurora PR
 
 ## [1.0.1] - 2022-04-12
 ### Changes
@@ -62,7 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 - feat: Initial commit
 
-[Unreleased]: https://github.com/boldlink/terraform-aws-rds-aurora/compare/1.0.4...HEAD
+[Unreleased]: https://github.com/boldlink/terraform-aws-rds-aurora/compare/1.0.5...HEAD
+[1.0.5]: https://github.com/boldlink/terraform-aws-rds-aurora/releases/tag/1.0.5
 [1.0.4]: https://github.com/boldlink/terraform-aws-rds-aurora/releases/tag/1.0.4
 [1.0.3]: https://github.com/boldlink/terraform-aws-rds-aurora/releases/tag/1.0.3
 [1.0.2]: https://github.com/boldlink/terraform-aws-rds-aurora/releases/tag/1.0.2

--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ module "minimum" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.15.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.60.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.63.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.12.0 |
 
 ## Modules
 
@@ -134,7 +134,7 @@ No modules.
 | <a name="input_enable_global_write_forwarding"></a> [enable\_global\_write\_forwarding](#input\_enable\_global\_write\_forwarding) | (Optional) Whether cluster should forward writes to an associated global cluster. | `bool` | `false` | no |
 | <a name="input_enable_http_endpoint"></a> [enable\_http\_endpoint](#input\_enable\_http\_endpoint) | (Optional) Enable HTTP endpoint (data API). Only valid when engine\_mode is set to serverless. | `bool` | `false` | no |
 | <a name="input_enabled_cloudwatch_logs_exports"></a> [enabled\_cloudwatch\_logs\_exports](#input\_enabled\_cloudwatch\_logs\_exports) | (Optional) Set of log types to export to cloudwatch. If omitted, no logs will be exported. The following log types are supported: audit, error, general, slowquery, postgresql (PostgreSQL) | `list(string)` | `[]` | no |
-| <a name="input_engine"></a> [engine](#input\_engine) | (Optional) The name of the database engine to be used for this DB cluster. Defaults to aurora. Valid Values: aurora, aurora-mysql, aurora-postgresql | `string` | `null` | no |
+| <a name="input_engine"></a> [engine](#input\_engine) | (Required) The name of the database engine to be used for this DB cluster. Defaults to aurora. Valid Values: aurora, aurora-mysql, aurora-postgresql | `string` | n/a | yes |
 | <a name="input_engine_mode"></a> [engine\_mode](#input\_engine\_mode) | (Optional) The database engine mode. Valid values: global (only valid for Aurora MySQL 1.21 and earlier), multimaster, parallelquery, provisioned, serverless. Defaults to: provisioned. | `string` | `null` | no |
 | <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | (Optional) The database engine version. Updating this argument results in an outage. The actual engine version used is returned in the attribute engine\_version\_actual. | `string` | `null` | no |
 | <a name="input_family"></a> [family](#input\_family) | (Required) The family of the DB cluster parameter group. | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ module "minimum" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.12.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.13.0 |
 
 ## Modules
 

--- a/examples/aurora-mysql/README.md
+++ b/examples/aurora-mysql/README.md
@@ -18,14 +18,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.15.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.10.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.63.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.12.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules

--- a/examples/aurora-mysql/README.md
+++ b/examples/aurora-mysql/README.md
@@ -25,7 +25,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.12.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.13.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules

--- a/examples/aurora-mysql/local.tf
+++ b/examples/aurora-mysql/local.tf
@@ -6,7 +6,7 @@ locals {
     Name               = local.cluster_name
     Environment        = "example"
     "user::CostCenter" = "terraform-registry"
-    department         = "operations"
+    Department         = "operations"
     InstanceScheduler  = true
     Project            = "aws-rds"
     Owner              = "Boldlink"

--- a/examples/aurora-mysql/main.tf
+++ b/examples/aurora-mysql/main.tf
@@ -33,6 +33,7 @@ module "rds_cluster" {
   storage_encrypted               = true
   kms_key_id                      = data.aws_kms_key.supporting.arn
   vpc_id                          = data.aws_vpc.supporting.id
+  tags                            = local.tags
   enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
   create_security_group           = true
   ingress_rules = {

--- a/examples/aurora-mysql/versions.tf
+++ b/examples/aurora-mysql/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.15.0"
+      version = ">= 5.10.0"
     }
 
     random = {

--- a/examples/aurora-postgresql/README.md
+++ b/examples/aurora-postgresql/README.md
@@ -18,14 +18,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.15.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.10.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.63.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.12.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules

--- a/examples/aurora-postgresql/README.md
+++ b/examples/aurora-postgresql/README.md
@@ -25,7 +25,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.12.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.13.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules

--- a/examples/aurora-postgresql/locals.tf
+++ b/examples/aurora-postgresql/locals.tf
@@ -6,7 +6,7 @@ locals {
     Name               = local.cluster_name
     Environment        = "example"
     "user::CostCenter" = "terraform-registry"
-    department         = "operations"
+    Department         = "operations"
     InstanceScheduler  = true
     Project            = "aws-rds"
     Owner              = "Boldlink"

--- a/examples/aurora-postgresql/main.tf
+++ b/examples/aurora-postgresql/main.tf
@@ -22,7 +22,7 @@ module "rds_cluster" {
   instance_count                  = 1
   availability_zones              = data.aws_availability_zones.available.names
   engine                          = "aurora-postgresql"
-  engine_version                  = "11.12"
+  engine_version                  = "12.15"
   port                            = 5432
   engine_mode                     = "provisioned"
   instance_class                  = "db.r5.2xlarge"

--- a/examples/aurora-postgresql/versions.tf
+++ b/examples/aurora-postgresql/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.15.0"
+      version = ">= 5.10.0"
     }
 
     random = {

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -18,15 +18,15 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.15.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.10.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.63.0 |
-| <a name="provider_aws.secondary"></a> [aws.secondary](#provider\_aws.secondary) | 4.63.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.12.0 |
+| <a name="provider_aws.secondary"></a> [aws.secondary](#provider\_aws.secondary) | 5.12.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules
@@ -36,7 +36,7 @@
 | <a name="module_global_cluster"></a> [global\_cluster](#module\_global\_cluster) | ../../modules/global-cluster | n/a |
 | <a name="module_primary_cluster"></a> [primary\_cluster](#module\_primary\_cluster) | ../../ | n/a |
 | <a name="module_secondary_cluster"></a> [secondary\_cluster](#module\_secondary\_cluster) | ../../ | n/a |
-| <a name="module_secondary_vpc"></a> [secondary\_vpc](#module\_secondary\_vpc) | boldlink/vpc/aws | 2.0.3 |
+| <a name="module_secondary_vpc"></a> [secondary\_vpc](#module\_secondary\_vpc) | boldlink/vpc/aws | 3.0.4 |
 
 ## Resources
 
@@ -51,13 +51,12 @@
 | [random_string.master_username](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_availability_zones.secondary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.backup](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_kms_key.supporting](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
-| [aws_region.secondary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_subnets.database](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_subnets.internal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.supporting](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -25,8 +25,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.12.0 |
-| <a name="provider_aws.secondary"></a> [aws.secondary](#provider\_aws.secondary) | 5.12.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.13.0 |
+| <a name="provider_aws.secondary"></a> [aws.secondary](#provider\_aws.secondary) | 5.13.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules

--- a/examples/complete/data.tf
+++ b/examples/complete/data.tf
@@ -1,7 +1,5 @@
 data "aws_partition" "current" {}
 
-data "aws_caller_identity" "current" {}
-
 data "aws_iam_policy_document" "monitoring" {
   statement {
     actions = [
@@ -31,10 +29,6 @@ data "aws_availability_zones" "secondary" {
   provider = aws.secondary
 }
 
-data "aws_region" "secondary" {
-  provider = aws.secondary
-}
-
 data "aws_vpc" "supporting" {
   filter {
     name   = "tag:Name"
@@ -56,4 +50,13 @@ data "aws_kms_key" "supporting" {
 
 data "aws_availability_zones" "available" {
   state = "available"
+}
+
+data "aws_subnets" "internal" {
+  filter {
+    name   = "tag:Name"
+    values = ["${local.supporting_resources_name}*.int.*"]
+  }
+  depends_on = [module.secondary_vpc]
+  provider   = aws.secondary
 }

--- a/examples/complete/locals.tf
+++ b/examples/complete/locals.tf
@@ -1,19 +1,18 @@
 locals {
   cluster_name              = "sample-global-aurora-cluster"
   supporting_resources_name = "terraform-aws-rds-aurora"
-  engine                    = "aurora"
-  engine_version            = "5.6.mysql_aurora.1.22.2"
+  engine                    = "aurora-mysql"
+  engine_version            = "5.7.mysql_aurora.2.11.3"
   global_cluster_identifier = local.cluster_name
   cidr_block                = "172.16.0.0/16"
+  internal_subnet_ids       = data.aws_subnets.internal.ids
   database_subnets          = cidrsubnets(local.cidr_block, 8, 8, 8)
-  secondary_azs             = flatten(data.aws_availability_zones.secondary.names)
   dns_suffix                = data.aws_partition.current.dns_suffix
 
   tags = {
-    Name               = local.cluster_name
     Environment        = "example"
     "user::CostCenter" = "terraform-registry"
-    department         = "operations"
+    Department         = "operations"
     InstanceScheduler  = true
     Project            = "aws-rds"
     Owner              = "Boldlink"

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.15.0"
+      version = ">= 5.10.0"
     }
 
     random = {

--- a/examples/minimum/README.md
+++ b/examples/minimum/README.md
@@ -18,14 +18,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.15.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.10.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.63.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.12.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules

--- a/examples/minimum/README.md
+++ b/examples/minimum/README.md
@@ -25,7 +25,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.12.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.13.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules

--- a/examples/minimum/local.tf
+++ b/examples/minimum/local.tf
@@ -5,7 +5,7 @@ locals {
     Name               = local.cluster_name
     Environment        = "example"
     "user::CostCenter" = "terraform-registry"
-    department         = "operations"
+    Department         = "operations"
     InstanceScheduler  = true
     Project            = "aws-rds"
     Owner              = "hugo.almeida"

--- a/examples/minimum/versions.tf
+++ b/examples/minimum/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.15.0"
+      version = ">= 5.10.0"
     }
 
     random = {

--- a/examples/serverless/README.md
+++ b/examples/serverless/README.md
@@ -18,14 +18,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.15.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.10.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.63.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.12.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules

--- a/examples/serverless/README.md
+++ b/examples/serverless/README.md
@@ -25,7 +25,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.12.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.13.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules

--- a/examples/serverless/local.tf
+++ b/examples/serverless/local.tf
@@ -7,7 +7,7 @@ locals {
     Name               = local.cluster_name
     Environment        = "example"
     "user::CostCenter" = "terraform-registry"
-    department         = "operations"
+    Department         = "operations"
     InstanceScheduler  = true
     Project            = "aws-rds"
     Owner              = "Boldlink"

--- a/examples/serverless/versions.tf
+++ b/examples/serverless/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.15.0"
+      version = ">= 5.10.0"
     }
 
     random = {

--- a/modules/global-cluster/README.md
+++ b/modules/global-cluster/README.md
@@ -30,13 +30,13 @@ Examples available [`here`](https://github.com/boldlink/terraform-aws-rds-aurora
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.15.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.60.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.63.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.12.0 |
 
 ## Modules
 

--- a/modules/global-cluster/README.md
+++ b/modules/global-cluster/README.md
@@ -36,7 +36,7 @@ Examples available [`here`](https://github.com/boldlink/terraform-aws-rds-aurora
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.12.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.13.0 |
 
 ## Modules
 

--- a/modules/global-cluster/versions.tf
+++ b/modules/global-cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.15.0"
+      version = ">= 4.60.0"
     }
   }
 }

--- a/tests/supportingResources/README.md
+++ b/tests/supportingResources/README.md
@@ -25,7 +25,7 @@ This stack builds:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=4.15.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=5.10.0 |
 
 ## Providers
 
@@ -35,7 +35,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aurora_vpc"></a> [aurora\_vpc](#module\_aurora\_vpc) | boldlink/vpc/aws | 3.0.2 |
+| <a name="module_aurora_vpc"></a> [aurora\_vpc](#module\_aurora\_vpc) | boldlink/vpc/aws | 3.0.4 |
 | <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | boldlink/kms/aws | n/a |
 
 ## Resources

--- a/tests/supportingResources/locals.tf
+++ b/tests/supportingResources/locals.tf
@@ -6,7 +6,7 @@ locals {
   tags = {
     Environment        = "examples"
     "user::CostCenter" = "terraform-registry"
-    department         = "operations"
+    Department         = "operations"
     Project            = "aws-vpc"
     Owner              = "Boldlink"
     LayerName          = "cExample"

--- a/tests/supportingResources/main.tf
+++ b/tests/supportingResources/main.tf
@@ -1,6 +1,6 @@
 module "aurora_vpc" {
   source                  = "boldlink/vpc/aws"
-  version                 = "3.0.2"
+  version                 = "3.0.4"
   name                    = local.name
   cidr_block              = local.cidr_block
   enable_internal_subnets = true

--- a/tests/supportingResources/versions.tf
+++ b/tests/supportingResources/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.15.1"
+      version = ">=5.10.0"
     }
   }
   required_version = ">= 0.14.11"

--- a/variables.tf
+++ b/variables.tf
@@ -108,9 +108,8 @@ variable "enabled_cloudwatch_logs_exports" {
 }
 
 variable "engine" {
-  description = "(Optional) The name of the database engine to be used for this DB cluster. Defaults to aurora. Valid Values: aurora, aurora-mysql, aurora-postgresql"
+  description = "(Required) The name of the database engine to be used for this DB cluster. Defaults to aurora. Valid Values: aurora, aurora-mysql, aurora-postgresql"
   type        = string
-  default     = null
 }
 
 variable "engine_mode" {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.15.0"
+      version = ">= 4.60.0"
     }
   }
 }


### PR DESCRIPTION
# Description

This PR was created to updated vpc module version in supporting resources and complete example due to deprecated arguments in previous version

## Features/Fixes/Patches/Changes list:

Please check the [CHANGELOG.md](https://github.com/boldlink/terraform-aws-rds-aurora/blob/fix/vpc-version-fix/CHANGELOG.md#105---2023-08-17)

## Checklists:
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
### PR Owners Checklist:
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you checked there aren't open [Pull Requests](../../../pulls) of upstream or parallel code that will cause conflicts?
* [ ] Have you updated the `CHANGELOG.md`?
* [ ] Have you updated the `README.md`(s)?
* [ ] OWNER: Does your submission pass?
    * [ ] Pre-commit (attach logs/print screen to this PR)
    * [ ] Checkov/terrascan (attach logs/print screen to this PR)
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] First PR? Have you deleted `## How to use this template...` from the root `.README.md`?

### PR Reviewers Checklists?
* [ ] Are all your comments/changes resolved?
* [ ] Are you happy with the OWNER checklists and additional information provided?
* [ ] Does your review tests pass?
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
